### PR TITLE
Update sdk

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.4
+current_version = 2.2.0
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ All you need to do is:
     <dependency>
       <groupId>com.ibm.watson.developer_cloud</groupId>
       <artifactId>watson-spring-boot-starter</artifactId>
-      <version>2.1.4</version>
+      <version>2.2.0</version>
     </dependency>
     ```
 
     or in your gradle `build.gradle`, in the dependencies stanza, add
     ```
-    compile 'com.ibm.watson.developer_cloud:watson-spring-boot-starter:2.1.4'
+    compile 'com.ibm.watson.developer_cloud:watson-spring-boot-starter:2.2.0'
     ```
 
 2. Add your Watson service(s) credentials and version info to your application

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@
 
 buildscript {
     repositories {
+        mavenCentral()
+        jcenter()
         maven { url 'https://repo.spring.io/plugins-release' }
     }
     dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.1.4
+version=2.2.0
 group = com.ibm.watson.developer_cloud
 watsonVersion = 9.0.2
 springVersion = 5.1.13.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=2.1.4
 group = com.ibm.watson.developer_cloud
-watsonVersion = 8.6.3
+watsonVersion = 9.0.2
 springVersion = 5.1.13.RELEASE
 springBootVersion = 2.2.0.RELEASE

--- a/src/main/java/com/ibm/watson/developer_cloud/spring/boot/WatsonAutoConfiguration.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/spring/boot/WatsonAutoConfiguration.java
@@ -16,6 +16,7 @@ package com.ibm.watson.developer_cloud.spring.boot;
 
 import com.ibm.cloud.sdk.core.security.Authenticator;
 import com.ibm.cloud.sdk.core.security.BasicAuthenticator;
+import com.ibm.cloud.sdk.core.security.BearerTokenAuthenticator;
 import com.ibm.cloud.sdk.core.security.ConfigBasedAuthenticatorFactory;
 import com.ibm.cloud.sdk.core.security.IamAuthenticator;
 import com.ibm.cloud.sdk.core.service.BaseService;
@@ -69,6 +70,10 @@ public class WatsonAutoConfiguration {
     if (apiKey != null) {
       return new WatsonApiKeyAuthenticator(apiKey);
     }
+    String bearerToken = config.getBearerToken();
+    if (bearerToken != null) {
+      return new BearerTokenAuthenticator(bearerToken);
+    }
 
     // If we can't find the right properties, we'll return what we get from the auth config factory, which will
     // pull from things like VCAP_SERVICES.
@@ -99,7 +104,7 @@ public class WatsonAutoConfiguration {
   @ConditionalOnMissingBean
   @ConditionalOnWatsonServiceProperties(prefix = WatsonAssistantV2ConfigurationProperties.PREFIX)
   public com.ibm.watson.assistant.v2.Assistant assistantV2() {
-    Authenticator authConfig = configAuth(assistantV2Config, "assistant_v2");
+    Authenticator authConfig = configAuth(assistantV2Config, "assistant");
     com.ibm.watson.assistant.v2.Assistant service =
             new com.ibm.watson.assistant.v2.Assistant(assistantV2Config.getVersionDate(), authConfig);
     configUrl(service, assistantConfig);
@@ -145,7 +150,7 @@ public class WatsonAutoConfiguration {
   @ConditionalOnMissingBean
   @ConditionalOnWatsonServiceProperties(prefix = WatsonDiscoveryV2ConfigurationProperties.PREFIX)
   public com.ibm.watson.discovery.v2.Discovery discoveryV2() {
-    Authenticator authConfig = configAuth(discoveryV2Config, "discovery_v2");
+    Authenticator authConfig = configAuth(discoveryV2Config, "discovery");
     com.ibm.watson.discovery.v2.Discovery service =
             new com.ibm.watson.discovery.v2.Discovery(discoveryV2Config.getVersionDate(), authConfig);
     configUrl(service, discoveryV2Config);

--- a/src/main/java/com/ibm/watson/developer_cloud/spring/boot/WatsonConfigurationProperties.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/spring/boot/WatsonConfigurationProperties.java
@@ -34,6 +34,9 @@ public class WatsonConfigurationProperties {
   /** Watson service versionDate. */
   private String versionDate;
 
+  /** Watson service bearerToken. */
+  private String bearerToken;
+
   public void setUrl(String url) {
     this.url = url;
   }
@@ -58,6 +61,10 @@ public class WatsonConfigurationProperties {
     this.versionDate = versionDate;
   }
 
+  public void setBearerToken(String bearerToken) {
+    this.bearerToken = bearerToken;
+  }
+
   public String getUrl() {
     return this.url;
   }
@@ -80,5 +87,9 @@ public class WatsonConfigurationProperties {
 
   public String getVersionDate() {
     return this.versionDate;
+  }
+
+  public String getBearerToken() {
+    return this.bearerToken;
   }
 }

--- a/src/main/java/com/ibm/watson/developer_cloud/spring/boot/WatsonServiceCondition.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/spring/boot/WatsonServiceCondition.java
@@ -26,8 +26,10 @@ public class WatsonServiceCondition implements Condition {
     String apiKey = conditionContext.getEnvironment().getProperty(prefix + ".apiKey");
     String iamApiKey = conditionContext.getEnvironment().getProperty(prefix + ".iamApiKey");
     String versionDate = conditionContext.getEnvironment().getProperty(prefix + ".versionDate");
+    String bearerToken = conditionContext.getEnvironment().getProperty(prefix + ".bearerToken");
+
     if (url != null || username != null || password != null || versionDate != null
-            || apiKey != null || iamApiKey != null) {
+            || apiKey != null || iamApiKey != null || bearerToken != null) {
       return true;
     }
 

--- a/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/AssistantAutoConfigTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/AssistantAutoConfigTest.java
@@ -62,7 +62,7 @@ public class AssistantAutoConfigTest {
       assertEquals(username, authenticator.getUsername());
       assertEquals(password, authenticator.getPassword());
 
-      Field versionField = Assistant.class.getDeclaredField("versionDate");
+      Field versionField = Assistant.class.getDeclaredField("version");
       versionField.setAccessible(true);
       assertEquals(versionDate, versionField.get(assistant));
     } catch (NoSuchFieldException | IllegalAccessException ex) {

--- a/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/AssistantIamAuthTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/AssistantIamAuthTest.java
@@ -59,7 +59,7 @@ public class AssistantIamAuthTest {
       IamAuthenticator authenticator = (IamAuthenticator) assistant.getAuthenticator();
       assertEquals(iamApiKey, authenticator.getApiKey());
 
-      Field versionField = Assistant.class.getDeclaredField("versionDate");
+      Field versionField = Assistant.class.getDeclaredField("version");
       versionField.setAccessible(true);
       assertEquals(versionDate, versionField.get(assistant));
     } catch (NoSuchFieldException | IllegalAccessException ex) {

--- a/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/AssistantV2AutoConfigTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/AssistantV2AutoConfigTest.java
@@ -62,7 +62,7 @@ public class AssistantV2AutoConfigTest {
       assertEquals(username, authenticator.getUsername());
       assertEquals(password, authenticator.getPassword());
 
-      Field versionField = Assistant.class.getDeclaredField("versionDate");
+      Field versionField = Assistant.class.getDeclaredField("version");
       versionField.setAccessible(true);
       assertEquals(versionDate, versionField.get(assistant));
     } catch (NoSuchFieldException | IllegalAccessException ex) {

--- a/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/CompareComplyAutoConfigTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/CompareComplyAutoConfigTest.java
@@ -62,7 +62,7 @@ public class CompareComplyAutoConfigTest {
       assertEquals(username, authenticator.getUsername());
       assertEquals(password, authenticator.getPassword());
 
-      Field versionField = CompareComply.class.getDeclaredField("versionDate");
+      Field versionField = CompareComply.class.getDeclaredField("version");
       versionField.setAccessible(true);
       assertEquals(versionDate, versionField.get(compareComply));
     } catch (NoSuchFieldException | IllegalAccessException ex) {

--- a/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/DiscoveryAutoConfigTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/DiscoveryAutoConfigTest.java
@@ -62,7 +62,7 @@ public class DiscoveryAutoConfigTest {
       assertEquals(username, authenticator.getUsername());
       assertEquals(password, authenticator.getPassword());
 
-      Field versionField = Discovery.class.getDeclaredField("versionDate");
+      Field versionField = Discovery.class.getDeclaredField("version");
       versionField.setAccessible(true);
       assertEquals(versionDate, versionField.get(discovery));
     } catch (NoSuchFieldException | IllegalAccessException ex) {

--- a/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/DiscoveryV2AutoConfigTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/DiscoveryV2AutoConfigTest.java
@@ -62,7 +62,7 @@ public class DiscoveryV2AutoConfigTest {
       assertEquals(username, authenticator.getUsername());
       assertEquals(password, authenticator.getPassword());
 
-      Field versionField = Discovery.class.getDeclaredField("versionDate");
+      Field versionField = Discovery.class.getDeclaredField("version");
       versionField.setAccessible(true);
       assertEquals(versionDate, versionField.get(discovery));
     } catch (NoSuchFieldException | IllegalAccessException ex) {

--- a/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/NaturalLanguageUnderstandingAutoConfigTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/NaturalLanguageUnderstandingAutoConfigTest.java
@@ -64,7 +64,7 @@ public class NaturalLanguageUnderstandingAutoConfigTest {
       assertEquals(username, authenticator.getUsername());
       assertEquals(password, authenticator.getPassword());
 
-      Field versionField = NaturalLanguageUnderstanding.class.getDeclaredField("versionDate");
+      Field versionField = NaturalLanguageUnderstanding.class.getDeclaredField("version");
       versionField.setAccessible(true);
       assertEquals(versionDate, versionField.get(naturalLanguageUnderstanding));
     } catch (NoSuchFieldException | IllegalAccessException ex) {

--- a/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/PersonalityInsightsAutoConfigTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/PersonalityInsightsAutoConfigTest.java
@@ -62,7 +62,7 @@ public class PersonalityInsightsAutoConfigTest {
       assertEquals(username, authenticator.getUsername());
       assertEquals(password, authenticator.getPassword());
 
-      Field versionField = PersonalityInsights.class.getDeclaredField("versionDate");
+      Field versionField = PersonalityInsights.class.getDeclaredField("version");
       versionField.setAccessible(true);
       assertEquals(versionDate, versionField.get(personalityInsights));
     } catch (NoSuchFieldException | IllegalAccessException ex) {

--- a/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/ToneAnalyzerAutoConfigTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/ToneAnalyzerAutoConfigTest.java
@@ -62,7 +62,7 @@ public class ToneAnalyzerAutoConfigTest {
       assertEquals(username, authenticator.getUsername());
       assertEquals(password, authenticator.getPassword());
 
-      Field versionField = ToneAnalyzer.class.getDeclaredField("versionDate");
+      Field versionField = ToneAnalyzer.class.getDeclaredField("version");
       versionField.setAccessible(true);
       assertEquals(versionDate, versionField.get(toneAnalyzer));
     } catch (NoSuchFieldException | IllegalAccessException ex) {

--- a/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/VisualRecognitionAutoConfigTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/spring/boot/test/VisualRecognitionAutoConfigTest.java
@@ -58,7 +58,7 @@ public class VisualRecognitionAutoConfigTest {
       WatsonApiKeyAuthenticator authenticator = (WatsonApiKeyAuthenticator) visualRecognition.getAuthenticator();
       assertEquals(apiKey, authenticator.getApiKey());
 
-      Field versionField = VisualRecognition.class.getDeclaredField("versionDate");
+      Field versionField = VisualRecognition.class.getDeclaredField("version");
       versionField.setAccessible(true);
       assertEquals(versionDate, versionField.get(visualRecognition));
     } catch (NoSuchFieldException | IllegalAccessException ex) {


### PR DESCRIPTION
* Use the latest version of the Java SDK (9.0.2).
* Add bearer token authentication ([request from issue](https://github.com/watson-developer-cloud/spring-boot-starter/issues/18)).
* Fix dependencies due to changes in spring.io (https://spring.io/blog/2020/10/29/notice-of-permissions-changes-to-repo-spring-io-fall-and-winter-2020)